### PR TITLE
Ratelimit branch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "cors": "^2.8.5",
         "dotenv": "^17.0.1",
         "express": "^5.1.0",
+        "express-rate-limit": "^8.0.1",
         "jsonwebtoken": "^9.0.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -2740,6 +2741,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.0.1.tgz",
+      "integrity": "sha512-aZVCnybn7TVmxO4BtlmnvX+nuz8qHW124KKJ8dumsBsmv5ZLxE0pYu7S2nwyRBGHHCAzdmnGyrc5U/rksSPO7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3138,6 +3157,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "cors": "^2.8.5",
     "dotenv": "^17.0.1",
     "express": "^5.1.0",
+    "express-rate-limit": "^8.0.1",
     "jsonwebtoken": "^9.0.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,7 +33,10 @@ function App() {
         try {
             const response = await fetch('http://localhost:5000/openrouter/api/generate-commit', {
                 method:'POST',
-                headers:{'Content-Type':'application/json'},
+                headers:{
+                    'Authorization': `Bearer ${localStorage.getItem('jwtToken')}`,
+                    'Content-Type':'application/json'
+                },
                 body: JSON.stringify({ prompt })
             })
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,31 +30,43 @@ function App() {
 
         setIsLoading(true);
         setIsSubmitSuccess(false);
-        // try {
-        //     const response = await fetch('http://localhost:5000/openrouter/api/generate-commit', {
-        //         method:'POST',
-        //         headers:{'Content-Type':'application/json'},
-        //         body: JSON.stringify({ prompt })
-        //     })
+        try {
+            const response = await fetch('http://localhost:5000/openrouter/api/generate-commit', {
+                method:'POST',
+                headers:{'Content-Type':'application/json'},
+                body: JSON.stringify({ prompt })
+            })
 
-        //     const data = await response.json();
+            if (!response.ok) {
+                const errorResponse = await response.text();
+                throw new Error(errorResponse);
+            }
 
-        //     setCommitMessage(data.modelResponse);
-        //     setIsLoading(false);
-        //     setIsSubmitSuccess(true);
-        //     console.log(data.message);
-        // } catch (error) {
-        //     console.error("Error:", error);
-        //     alert("Error: Failed to generate commit message.");
-        // }
+            const data = await response.json();
 
-        // for testing, simulate fetch
-        setTimeout(() => {
-            setCommitMessage('dummy data');
+            setCommitMessage(data.modelResponse);
+
             setIsLoading(false);
             setIsSubmitSuccess(true);
-        }, 2000);
+            console.log(data.message);
+        } catch (error) {
+            if (error instanceof Error) {
+                console.error("Error:", error.message);
+            } else {
+                console.error("Unknown error:", error);
+            }
+            alert("Error: Failed to generate commit message.");
+            setIsLoading(false);
+        }
 
+        // for testing, simulate fetch
+        // setTimeout(() => {
+        //     setCommitMessage('dummy data');
+        //     setIsLoading(false);
+        //     setIsSubmitSuccess(true);
+        // }, 2000);
+        // getOpenRouterUsageLimits();
+        
         setPrompt('');
         setEmptyPromptError(false);
     }
@@ -65,6 +77,15 @@ function App() {
         localStorage.removeItem('jwtToken');
         console.log('successfully logged out');
         navigate('/');
+    }
+
+    const getOpenRouterUsageLimits = async () => {
+        const response = await fetch('http://localhost:5000/openrouter/api/get-usage-limits', {
+            method:'GET',
+        })
+
+        const data = await response.json();
+        console.log(data.message);
     }
 
     return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -80,6 +80,7 @@ function App() {
     }
 
     const getOpenRouterUsageLimits = async () => {
+        // fetches the usage limits from openrouter, credits used and limit will be undefined if using free model
         const response = await fetch('http://localhost:5000/openrouter/api/get-usage-limits', {
             method:'GET',
         })

--- a/src/routes/openrouter.cjs
+++ b/src/routes/openrouter.cjs
@@ -1,6 +1,7 @@
 const express = require('express')
 const router = express.Router()
 const jwt = require('jsonwebtoken')
+const rateLimit = require('express-rate-limit')
 
 // check for valid JWT in localstorage
 function authenticateToken(req, res, next) {
@@ -16,8 +17,18 @@ function authenticateToken(req, res, next) {
     });
 }
 
+// rate limiter for OpenRouter API calls
+const openRouterLimiter = rateLimit({
+    windowMs: 1 * 60 * 1000, // 1 minute
+    max: 3, // Max 3 requests per minute
+    message: { error: "Too many requests. Please try again later." },
+    standardHeaders: true, // Return rate limit info in the RateLimit-* headers
+    legacyHeaders: false,  // Disable the deprecated X-RateLimit-* headers
+});
+
+
 // post the prompt to the model via openrouter's api, and returns a response
-router.post('/api/generate-commit', async (req, res) => {
+router.post('/api/generate-commit', openRouterLimiter, async (req, res) => {
     const { prompt } = req.body;
 
     if (!prompt) {

--- a/src/routes/openrouter.cjs
+++ b/src/routes/openrouter.cjs
@@ -28,7 +28,7 @@ const openRouterLimiter = rateLimit({
 
 
 // post the prompt to the model via openrouter's api, and returns a response
-router.post('/api/generate-commit', openRouterLimiter, async (req, res) => {
+router.post('/api/generate-commit', authenticateToken, openRouterLimiter, async (req, res) => {
     const { prompt } = req.body;
 
     if (!prompt) {

--- a/src/routes/openrouter.cjs
+++ b/src/routes/openrouter.cjs
@@ -2,6 +2,7 @@ const express = require('express')
 const router = express.Router()
 const jwt = require('jsonwebtoken')
 
+// check for valid JWT in localstorage
 function authenticateToken(req, res, next) {
     const authHeader = req.headers['authorization'];
     const token = authHeader?.split(' ')[1];
@@ -15,7 +16,8 @@ function authenticateToken(req, res, next) {
     });
 }
 
-router.post('/api/generate-commit', authenticateToken, async (req, res) => {
+// post the prompt to the model via openrouter's api, and returns a response
+router.post('/api/generate-commit', async (req, res) => {
     const { prompt } = req.body;
 
     if (!prompt) {
@@ -27,12 +29,11 @@ router.post('/api/generate-commit', authenticateToken, async (req, res) => {
         const response = await fetch("https://openrouter.ai/api/v1/chat/completions", {
             method: "POST",
             headers: {
-                "Authorization": `Bearer ${process.env.OPENROUTER_API_KEY}`,
+                "Authorization": `Bearer ${process.env.OPENROUTER_API_KEY_NEW}`,
                 "Content-Type": "application/json"
             },
             body: JSON.stringify({
-                "model": "deepseek/deepseek-chat:free",
-                "max_tokens": 100,
+                "model": "deepseek/deepseek-r1:free",
                 "messages": [
                     {
                         "role": "user",
@@ -55,6 +56,35 @@ router.post('/api/generate-commit', authenticateToken, async (req, res) => {
     } catch (error) {
         console.log('Error in generating a git commit message: ', error);
         return res.status(500).json({ message: 'Failed to generate commit message.' });
+    }
+})
+
+
+// get openrouter usage limits
+router.get('/api/get-usage-limits', async (req, res) => {
+    try {
+        const response = await fetch('https://openrouter.ai/api/v1/key', {
+            method: 'GET',
+            headers: {
+                Authorization: `Bearer ${process.env.OPENROUTER_API_KEY_NEW}`,
+            },
+        });
+
+        if (!response.ok) {
+            const errorText = await response.text(); // get raw response text
+            console.error('OpenRouter returned error:', errorText);
+            return res.status(response.status).json({ message: `OpenRouter API error: ${errorText}` });
+        }
+
+        const data = await response.json();
+        
+        return res.status(200).json({ 
+            message: 'Successfully fetched openrouter usage limits.',
+            creditsUsed: `${data.usage}`,
+            creditLimit: `${data.limit}`
+        });
+    } catch (error) {
+        return res.status(500).json({ message: 'Failed to fetched openrouter usage limits.' });
     }
 })
 

--- a/src/server.cjs
+++ b/src/server.cjs
@@ -1,4 +1,12 @@
-require('dotenv').config();
+const path = require('path')
+require('dotenv').config({ path: path.resolve(__dirname, '../.env') });
+
+if (!process.env.OPENROUTER_API_KEY) {
+    console.log('OpenRouter API key failed to load.');
+} else {
+    console.log('OpenRouter API key successfully loaded.')
+}
+
 const express = require('express');
 const cors = require('cors')
 

--- a/src/server.cjs
+++ b/src/server.cjs
@@ -1,10 +1,10 @@
 const path = require('path')
 require('dotenv').config({ path: path.resolve(__dirname, '../.env') });
 
-if (!process.env.OPENROUTER_API_KEY) {
-    console.log('OpenRouter API key failed to load.');
+if (!process.env.OPENROUTER_API_KEY_NEW) {
+    console.log('OpenRouter API key NEW failed to load.');
 } else {
-    console.log('OpenRouter API key successfully loaded.')
+    console.log('OpenRouter API key NEW successfully loaded.')
 }
 
 const express = require('express');


### PR DESCRIPTION
- add ratelimiter to calling of openrouter's api via express-rate-limit
- fix issue of 401 unathorized when passing the prompt to the openrouter's model, by ensuring that a jwtToken is passed as a header in the api call of generate-commit